### PR TITLE
resolve deprecated problem of pandas

### DIFF
--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -125,7 +125,7 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
         by_day = data
     else:
         # Sample by day.
-        by_day = data.resample('D', how=how)
+        by_day = data.resample('D').sum()
 
     # Min and max per day.
     if vmin is None:
@@ -291,7 +291,7 @@ def calendarplot(data, how='sum', yearlabels=True, yearascending=True, yearlabel
     if how is None:
         by_day = data
     else:
-        by_day = data.resample('D', how=how)
+        by_day = data.resample('D').sum()
 
     ylabel_kws = dict(
         fontsize=32,


### PR DESCRIPTION
I got the following warning and make this patch.  
/usr/local/lib/python2.7/site-packages/calmap/**init**.py:295: FutureWarning: how in .resample() is deprecated
the new syntax is .resample(...).sum()
  # by_day = data.resample('D', how=how)

`data.resample('D', how=how)` is deprecated and use `data.resample('D').sum()` instead.
