### PR TITLE
Remove support for Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: python
 sudo: false
 cache: pip
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 install:

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Topic :: Scientific/Engineering']


### PR DESCRIPTION
This is just matching Pandas 0.18.

https://github.com/pydata/pandas/issues/7718
https://github.com/pydata/pandas/issues/11273
