### PR TITLE
Adds a month separator feature (#14)

### DIFF
--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -9,7 +9,6 @@ similar to GitHub's contributions calendar.
 from __future__ import unicode_literals
 
 import calendar
-import datetime
 
 from matplotlib.colors import ColorConverter, ListedColormap
 import matplotlib.pyplot as plt
@@ -31,6 +30,7 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
              fillcolor='whitesmoke', linewidth=1, linecolor=None,
              daylabels=calendar.day_abbr[:], dayticks=True,
              monthlabels=calendar.month_abbr[1:], monthticks=True, ax=None,
+             monthseparator=False, separatorwidth=3, separatorcolor='black',
              **kwargs):
     """
     Plot one year from a timeseries as a calendar heatmap.
@@ -69,6 +69,12 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
         If `True`, label all months. If `False`, don't label months. If a
         list, only label months with these indices. If an integer, label every
         n month.
+    monthseparator : bool
+        If `True`, adds line between months.
+    separatorwidth : float
+        Width of the month separators.
+    separatorcolor : string
+        Color of the month separators.
     ax : matplotlib Axes
         Axes in which to draw the plot, otherwise use the currently-active
         Axes.
@@ -158,7 +164,8 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
     by_day = pd.DataFrame({'data': by_day,
                            'fill': 1,
                            'day': by_day.index.dayofweek,
-                           'week': by_day.index.week})
+                           'week': by_day.index.week,
+                           'month': by_day.index.month})
 
     # There may be some days assigned to previous year's last week or
     # next year's first week. We create new week numbers for them so
@@ -183,8 +190,23 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
     kwargs['edgecolors'] = linecolor
     ax.pcolormesh(plot_data, vmin=vmin, vmax=vmax, cmap=cmap, **kwargs)
 
-    # Limit heatmap to our data.
-    ax.set(xlim=(0, plot_data.shape[1]), ylim=(0, plot_data.shape[0]))
+    # Limit heatmap to our data. Add a little room for the outside lines (purely esthetic)
+    ax.set(xlim=(-0.3, plot_data.shape[1] + 0.3), ylim=(-0.3, plot_data.shape[0] + 0.3))
+
+    # Draw lines at the start of each month
+    if monthseparator:
+        linekwargs = {'c': separatorcolor, 'lw': separatorwidth, 'ls': '-'}
+        for key, fd in by_day.groupby('month').first().iterrows():
+            x = [fd.week - 1, fd.week - 1, fd.week, fd.week]
+            y = [0, 7 - fd.day, 7 - fd.day, 7]
+            ax.plot(x, y, **linekwargs)
+        last = by_day.iloc[-1]
+        # Draw line at the end of December
+        ax.plot([last.week - 1, last.week - 1, last.week, last.week],
+                [0, 6 - last.day, 6 - last.day, 7], **linekwargs)
+        # Draw upper and lower part of the box
+        ax.plot([1, by_day.week.max()], [7, 7], **linekwargs)
+        ax.plot([0, by_day.week.max() - 1], [0, 0], **linekwargs)
 
     # Square cells.
     ax.set_aspect('equal')
@@ -212,8 +234,7 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
         dayticks = range(len(daylabels))[dayticks // 2::dayticks]
 
     ax.set_xlabel('')
-    ax.set_xticks([by_day.ix[datetime.date(year, i + 1, 15)].week
-                   for i in monthticks])
+    ax.set_xticks(by_day.groupby('month')['week'].mean().values - 0.5)
     ax.set_xticklabels([monthlabels[i] for i in monthticks], ha='center')
 
     ax.set_ylabel('')

--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -170,7 +170,9 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
     # There may be some days assigned to previous year's last week or
     # next year's first week. We create new week numbers for them so
     # the ordering stays intact and week/day pairs unique.
-    by_day.loc[(by_day.index.month == 1) & (by_day.week > 50), 'week'] = 0
+    if by_day.loc[(by_day.index.month == 1), 'week'].max() > 50:
+        by_day.loc[(by_day.index.month == 1) & (by_day.week > 50), 'week'] = 0
+        by_day.week = by_day.week + 1
     by_day.loc[(by_day.index.month == 12) & (by_day.week < 10), 'week'] \
         = by_day.week.max() + 1
 


### PR DESCRIPTION
To draw the lines, I had to modify some part of the code:

1.  Added a "month" column to the dataframe.
2.  If the first days of the year are part of last year's week (would be week 52), offset every week by 1 so they are now week 1, the previous week 1 is now week 2, etc. This is so that we know where to draw the lines.
3.  I have added a small padding to the axes (0.3 of one cell) in order to avoid the outside lines being cut by the axes limit.
4.  The month ticks position has been slightly pushed to the left so that their center now lines up with the center of the average week number.

This PR will break the tests because the output images are going to be different. This is not due to the month separator per se but to the slight esthetic changes (more margin and tick labels more centered). Would need to regenerate the baseline images.