### PR TITLE
Fix matplotlib deprecated function call

### DIFF
--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -148,7 +148,7 @@ def yearplot(data, year=None, how='sum', vmin=None, vmax=None, cmap='Reds',
         # of course won't work when the axes itself has a transparent
         # background so in that case we default to white which will usually be
         # the figure or canvas background color.
-        linecolor = ax.get_axis_bgcolor()
+        linecolor = ax.get_fc()
         if ColorConverter().to_rgba(linecolor)[-1] == 0:
             linecolor = 'white'
 


### PR DESCRIPTION
ax.get_axis_bgcolor() in line 151 is deprecated and removed, it is now used as ax.get_fc()